### PR TITLE
ci: bump golangci-lint to v1.54

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,6 @@ jobs:
           cache-dependency-path: go.sum
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.48
+          version: v1.54
           skip-cache: true
           args: --timeout 10m --verbose

--- a/internal/adapters/terraform/aws/ec2/autoscaling.go
+++ b/internal/adapters/terraform/aws/ec2/autoscaling.go
@@ -70,6 +70,7 @@ func adaptLaunchConfiguration(resource *terraform.Block) ec2.LaunchConfiguration
 		UserData:        defsecTypes.StringDefault("", resource.GetMetadata()),
 	}
 
+	//#nosec G101 -- False positive
 	if resource.TypeLabel() == "aws_launch_configuration" {
 		nameAttr := resource.GetAttribute("name")
 		launchConfig.Name = nameAttr.AsStringValueOrDefault("", resource)


### PR DESCRIPTION
In v1.51 added support for Go 1.20.