### PR TITLE
chore(deps): Bump down go version for commercial

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aquasecurity/trivy-iac
 
-go 1.20
+go 1.19
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/pkg/scanners/cloudformation/parser/parser.go
+++ b/pkg/scanners/cloudformation/parser/parser.go
@@ -202,18 +202,18 @@ func (p *Parser) parseParams() error {
 
 	params := make(Parameters)
 
-	var errs []error
+	var errs []string
 
 	for _, path := range p.parameterFiles {
 		if parameters, err := p.parseParametersFile(path); err != nil {
-			errs = append(errs, err)
+			errs = append(errs, err.Error())
 		} else {
 			params.Merge(parameters)
 		}
 	}
 
 	if len(errs) != 0 {
-		return errors.Join(errs...)
+		return errors.New(strings.Join(errs, "\n"))
 	}
 
 	params.Merge(p.parameters)


### PR DESCRIPTION
Commercial still requires us to be on Go 1.19.