### PR TITLE
feat(terraform): add an option to skip cached modules

### DIFF
--- a/pkg/scanners/terraform/options.go
+++ b/pkg/scanners/terraform/options.go
@@ -194,6 +194,14 @@ func ScannerWithDownloadsAllowed(allowed bool) options.ScannerOption {
 	}
 }
 
+func ScannerWithSkipCachedModules(b bool) options.ScannerOption {
+	return func(s options.ConfigurableScanner) {
+		if tf, ok := s.(ConfigurableTerraformScanner); ok {
+			tf.AddParserOptions(parser.OptionWithDownloads(b))
+		}
+	}
+}
+
 func ScannerWithConfigsFileSystem(fsys fs.FS) options.ScannerOption {
 	return func(s options.ConfigurableScanner) {
 		if tf, ok := s.(ConfigurableTerraformScanner); ok {

--- a/pkg/scanners/terraform/parser/evaluator.go
+++ b/pkg/scanners/terraform/parser/evaluator.go
@@ -25,18 +25,19 @@ const (
 )
 
 type evaluator struct {
-	filesystem      fs.FS
-	ctx             *tfcontext.Context
-	blocks          terraform.Blocks
-	inputVars       map[string]cty.Value
-	moduleMetadata  *modulesMetadata
-	projectRootPath string // root of the current scan
-	modulePath      string
-	moduleName      string
-	ignores         terraform.Ignores
-	parentParser    *Parser
-	debug           debug.Logger
-	allowDownloads  bool
+	filesystem        fs.FS
+	ctx               *tfcontext.Context
+	blocks            terraform.Blocks
+	inputVars         map[string]cty.Value
+	moduleMetadata    *modulesMetadata
+	projectRootPath   string // root of the current scan
+	modulePath        string
+	moduleName        string
+	ignores           terraform.Ignores
+	parentParser      *Parser
+	debug             debug.Logger
+	allowDownloads    bool
+	skipCachedModules bool
 }
 
 func newEvaluator(
@@ -53,6 +54,7 @@ func newEvaluator(
 	ignores []terraform.Ignore,
 	logger debug.Logger,
 	allowDownloads bool,
+	skipCachedModules bool,
 ) *evaluator {
 
 	// create a context to store variables and make functions available

--- a/pkg/scanners/terraform/parser/load_module.go
+++ b/pkg/scanners/terraform/parser/load_module.go
@@ -159,8 +159,9 @@ func (e *evaluator) loadExternalModule(ctx context.Context, b *terraform.Block, 
 		ModulePath:      e.modulePath,
 		DebugLogger:     e.debug.Extend("resolver"),
 		AllowDownloads:  e.allowDownloads,
-		AllowCache:      e.allowDownloads,
+		SkipCache:       e.skipCachedModules,
 	}
+
 	filesystem, prefix, path, err := resolveModule(ctx, e.filesystem, opt)
 	if err != nil {
 		return nil, err

--- a/pkg/scanners/terraform/parser/option.go
+++ b/pkg/scanners/terraform/parser/option.go
@@ -12,6 +12,7 @@ type ConfigurableTerraformParser interface {
 	SetStopOnHCLError(bool)
 	SetWorkspaceName(string)
 	SetAllowDownloads(bool)
+	SetSkipCachedModules(bool)
 	SetConfigsFS(fsys fs.FS)
 }
 
@@ -45,6 +46,14 @@ func OptionWithDownloads(allowed bool) options.ParserOption {
 	return func(p options.ConfigurableParser) {
 		if tf, ok := p.(ConfigurableTerraformParser); ok {
 			tf.SetAllowDownloads(allowed)
+		}
+	}
+}
+
+func OptionWithSkipCachedModules(b bool) options.ParserOption {
+	return func(p options.ConfigurableParser) {
+		if tf, ok := p.(ConfigurableTerraformParser); ok {
+			tf.SetSkipCachedModules(b)
 		}
 	}
 }

--- a/pkg/scanners/terraform/parser/parser.go
+++ b/pkg/scanners/terraform/parser/parser.go
@@ -43,25 +43,26 @@ var _ ConfigurableTerraformParser = (*Parser)(nil)
 
 // Parser is a tool for parsing terraform templates at a given file system location
 type Parser struct {
-	projectRoot    string
-	moduleName     string
-	modulePath     string
-	moduleSource   string
-	moduleFS       fs.FS
-	moduleBlock    *terraform.Block
-	files          []sourceFile
-	tfvarsPaths    []string
-	stopOnHCLError bool
-	workspaceName  string
-	underlying     *hclparse.Parser
-	children       []*Parser
-	metrics        Metrics
-	options        []options.ParserOption
-	debug          debug.Logger
-	allowDownloads bool
-	fsMap          map[string]fs.FS
-	skipRequired   bool
-	configsFS      fs.FS
+	projectRoot       string
+	moduleName        string
+	modulePath        string
+	moduleSource      string
+	moduleFS          fs.FS
+	moduleBlock       *terraform.Block
+	files             []sourceFile
+	tfvarsPaths       []string
+	stopOnHCLError    bool
+	workspaceName     string
+	underlying        *hclparse.Parser
+	children          []*Parser
+	metrics           Metrics
+	options           []options.ParserOption
+	debug             debug.Logger
+	allowDownloads    bool
+	skipCachedModules bool
+	fsMap             map[string]fs.FS
+	skipRequired      bool
+	configsFS         fs.FS
 }
 
 func (p *Parser) SetDebugWriter(writer io.Writer) {
@@ -82,6 +83,10 @@ func (p *Parser) SetWorkspaceName(s string) {
 
 func (p *Parser) SetAllowDownloads(b bool) {
 	p.allowDownloads = b
+}
+
+func (p *Parser) SetSkipCachedModules(b bool) {
+	p.skipCachedModules = b
 }
 
 func (p *Parser) SetSkipRequiredCheck(b bool) {
@@ -303,6 +308,7 @@ func (p *Parser) EvaluateAll(ctx context.Context) (terraform.Modules, cty.Value,
 		ignores,
 		p.debug.Extend("evaluator"),
 		p.allowDownloads,
+		p.skipCachedModules,
 	)
 	modules, fsMap, parseDuration := evaluator.EvaluateAll(ctx)
 	p.metrics.Counts.Modules = len(modules)

--- a/pkg/scanners/terraform/parser/parser_integration_test.go
+++ b/pkg/scanners/terraform/parser/parser_integration_test.go
@@ -20,7 +20,7 @@ module "registry" {
 `,
 	})
 
-	parser := New(fs, "", OptionStopOnHCLError(true))
+	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
 	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ module "registry" {
 `,
 	})
 
-	parser := New(fs, "", OptionStopOnHCLError(true))
+	parser := New(fs, "", OptionStopOnHCLError(true), OptionWithSkipCachedModules(true))
 	if err := parser.ParseFS(context.TODO(), "code"); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/scanners/terraform/parser/resolvers/cache.go
+++ b/pkg/scanners/terraform/parser/resolvers/cache.go
@@ -35,7 +35,7 @@ func locateCacheDir() (string, error) {
 }
 
 func (r *cacheResolver) Resolve(_ context.Context, _ fs.FS, opt Options) (filesystem fs.FS, prefix string, downloadPath string, applies bool, err error) {
-	if !opt.AllowCache {
+	if opt.SkipCache {
 		opt.Debug("Cache is disabled.")
 		return nil, "", "", false, nil
 	}

--- a/pkg/scanners/terraform/parser/resolvers/options.go
+++ b/pkg/scanners/terraform/parser/resolvers/options.go
@@ -10,7 +10,7 @@ type Options struct {
 	Source, OriginalSource, Version, OriginalVersion, WorkingDir, Name, ModulePath string
 	DebugLogger                                                                    debug.Logger
 	AllowDownloads                                                                 bool
-	AllowCache                                                                     bool
+	SkipCache                                                                      bool
 	RelativePath                                                                   string
 }
 

--- a/pkg/scanners/terraform/scanner_integration_test.go
+++ b/pkg/scanners/terraform/scanner_integration_test.go
@@ -54,6 +54,7 @@ deny[res] {
 		options.ScannerWithEmbeddedLibraries(false),
 		options.ScannerWithRegoOnly(true),
 		ScannerWithAllDirectories(true),
+		ScannerWithSkipCachedModules(true),
 	)
 
 	results, err := scanner.ScanFS(context.TODO(), fs, ".")
@@ -117,6 +118,7 @@ deny[res] {
 		options.ScannerWithEmbeddedLibraries(false),
 		options.ScannerWithRegoOnly(true),
 		ScannerWithAllDirectories(true),
+		ScannerWithSkipCachedModules(true),
 	)
 
 	results, err := scanner.ScanFS(context.TODO(), fs, ".")


### PR DESCRIPTION
The option to skip cached modules will allow to avoid failure of integration tests depending on remote repositories in case of a broken cache.