### PR TITLE
Fix discrepancy with terraform in handling `TF_TOKEN`: Optionally transform `-` character in hostname for TF_TOKEN to `__`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/zclconf/go-cty-yaml v1.0.3
 	golang.org/x/crypto v0.18.0
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	golang.org/x/net v0.20.0
 	golang.org/x/text v0.14.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.13.3
@@ -181,7 +182,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/mod v0.13.0 // indirect
-	golang.org/x/net v0.20.0 // indirect
 	golang.org/x/oauth2 v0.13.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/pkg/scanners/terraform/parser/resolvers/registry.go
+++ b/pkg/scanners/terraform/parser/resolvers/registry.go
@@ -57,6 +57,12 @@ func (r *registryResolver) Resolve(ctx context.Context, target fs.FS, opt Option
 
 		envVar := fmt.Sprintf("TF_TOKEN_%s", strings.ReplaceAll(hostname, ".", "_"))
 		token = os.Getenv(envVar)
+
+		if token == "" {
+			envVar = strings.ReplaceAll(hostname, "-", "__")
+			token = os.Getenv(envVar)
+		}
+
 		if token != "" {
 			opt.Debug("Found a token for the registry at %s", hostname)
 		} else {

--- a/pkg/scanners/terraform/parser/resolvers/registry_test.go
+++ b/pkg/scanners/terraform/parser/resolvers/registry_test.go
@@ -1,0 +1,50 @@
+package resolvers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getPrivateRegistryTokenFromEnvVars(t *testing.T) {
+	t.Run("returns empty string when no env var set", func(t *testing.T) {
+		token, err := getPrivateRegistryTokenFromEnvVars("registry.example.com")
+		assert.Equal(t, "", token)
+		assert.Equal(t, "No token was found for the registry at registry.example.com", err.Error())
+	})
+
+	t.Run("returns string when simple env var set", func(t *testing.T) {
+		t.Setenv("TF_TOKEN_registry_example_com", "abcd")
+		token, err := getPrivateRegistryTokenFromEnvVars("registry.example.com")
+		assert.Equal(t, "abcd", token)
+		assert.Equal(t, nil, err)
+	})
+
+	t.Run("allows dashes in hostname to be dashes", func(t *testing.T) {
+		t.Setenv("TF_TOKEN_my-registry_example_com", "1111")
+		token, err := getPrivateRegistryTokenFromEnvVars("my-registry.example.com")
+		assert.Equal(t, "1111", token)
+		assert.Equal(t, nil, err)
+	})
+
+	t.Run("allows dashes in hostname to be double underscores", func(t *testing.T) {
+		t.Setenv("TF_TOKEN_my__registry_example_com", "1234")
+		token, err := getPrivateRegistryTokenFromEnvVars("my-registry.example.com")
+		assert.Equal(t, "1234", token)
+		assert.Equal(t, nil, err)
+	})
+
+	t.Run("handles utf8 to punycode correctly", func(t *testing.T) {
+		t.Setenv("TF_TOKEN_xn--r8j3dr99h_com", "9999")
+		token, err := getPrivateRegistryTokenFromEnvVars("例えば.com")
+		assert.Equal(t, "9999", token)
+		assert.Equal(t, nil, err)
+	})
+
+	t.Run("handles punycode with dash to underscore conversion", func(t *testing.T) {
+		t.Setenv("TF_TOKEN_xn____caf__dma_fr", "9875")
+		token, err := getPrivateRegistryTokenFromEnvVars("café.fr")
+		assert.Equal(t, "9875", token)
+		assert.Equal(t, nil, err)
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/aquasecurity/trivy/discussions/6067

This issue prevents me from accessing a private terraform module repo with a `-` in the hostname.